### PR TITLE
Extension: Multiple addresses

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -45,7 +45,12 @@ class CartsController < ApplicationController
   end
 
   def checkout
-    new_order = current_user.orders.create
+    address = Address.find(params[:address_id])
+    # new_order = current_user.orders.create
+    new_order = Order.create
+    new_order.address_id = address.id
+    current_user.orders << new_order
+    new_order.save
     cart.item_and_quantity_hash.each do |item, quantity|
       OrderItem.create(item: item, order: new_order, quantity: quantity, price_per_item: item.price)
     end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -8,7 +8,6 @@ class CartsController < ApplicationController
     redirect_to items_path
   end
 
-
   def increment
     item = Item.find(params[:id])
     add_to_cart(item)

--- a/app/controllers/user/addresses_controller.rb
+++ b/app/controllers/user/addresses_controller.rb
@@ -1,0 +1,24 @@
+class User::AddressesController < User::BaseController
+  def new
+    @user = current_user
+    @address = Address.new
+  end
+
+  def create
+    address = Address.new(address_params)
+    address.user_id = params[:format]
+    if address.save
+      flash[:notice] = "The address for #{address.street} has been saved."
+      redirect_to profile_path
+    else
+      flash[:error] = address.errors.full_messages.join(". ")
+      render :new
+    end
+  end
+
+  private
+
+  def address_params
+    params.require(:address).permit(:nickname, :street, :city, :state, :zip)
+  end
+end

--- a/app/controllers/user/addresses_controller.rb
+++ b/app/controllers/user/addresses_controller.rb
@@ -24,6 +24,19 @@ class User::AddressesController < User::BaseController
     redirect_to profile_path
   end
 
+  def edit
+    @address = Address.find(params[:id])
+  end
+
+  def update
+    address = Address.find(params[:id])
+    if address.update_attributes(address_params)
+      redirect_to profile_path
+    else
+      render :edit
+    end
+  end
+
   private
 
   def address_params

--- a/app/controllers/user/addresses_controller.rb
+++ b/app/controllers/user/addresses_controller.rb
@@ -8,12 +8,20 @@ class User::AddressesController < User::BaseController
     address = Address.new(address_params)
     address.user_id = params[:format]
     if address.save
-      flash[:notice] = "The address for #{address.street} has been saved."
+      flash[:notice] = "Your address at #{address.street} was saved."
       redirect_to profile_path
     else
       flash[:error] = address.errors.full_messages.join(". ")
       render :new
     end
+  end
+
+  def destroy
+    address = Address.find(params[:id])
+    address.user_id == current_user.id
+    address.destroy
+    flash[:notice] = "Your address was deleted."
+    redirect_to profile_path
   end
 
   private

--- a/app/controllers/user/users_controller.rb
+++ b/app/controllers/user/users_controller.rb
@@ -1,13 +1,15 @@
 class User::UsersController < User::BaseController
   def show
     @user_orders = current_user.orders
+    @addresses = current_user.addresses
   end
 
   def edit
+    @user = current_user
   end
 
   def update
-    if current_user.email != params[:email].downcase && User.find_by(email: params[:email].downcase)
+    if current_user.email != params[:user][:email].downcase && User.find_by(email: params[:user][:email].downcase)
       flash[:error] = "That email address is already in use"
       redirect_to profile_edit_path
       return
@@ -26,12 +28,6 @@ class User::UsersController < User::BaseController
   private
 
   def update_params
-    altered_params = params.permit(:name, :email, :address, :city, :state, :zip, :password, :password_confirmation)
-
-    if params[:password] == "" || params[:password_confirmation] == ""
-      altered_params = altered_params.except(:password).except(:password_confirmation)
-    end
-
-    altered_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, addresses_attributes: [:id, :street, :city, :state, :zip])
   end
 end

--- a/app/controllers/user/users_controller.rb
+++ b/app/controllers/user/users_controller.rb
@@ -28,6 +28,6 @@ class User::UsersController < User::BaseController
   private
 
   def update_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation, addresses_attributes: [:id, :street, :city, :state, :zip])
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, addresses_attributes: [:id, :nickname, :street, :city, :state, :zip])
   end
 end

--- a/app/controllers/user/users_controller.rb
+++ b/app/controllers/user/users_controller.rb
@@ -1,7 +1,7 @@
 class User::UsersController < User::BaseController
   def show
     @user_orders = current_user.orders
-    @addresses = current_user.addresses
+    @addresses = current_user.addresses.reload
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
 
   def new
     @user = User.new
+    @address = @user.addresses.build
   end
 
   def create
@@ -19,6 +20,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :address, :city, :state, :zip, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, addresses_attributes: [:id, :street, :city, :state, :zip])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation, addresses_attributes: [:id, :street, :city, :state, :zip])
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, addresses_attributes: [:id, :nickname, :street, :city, :state, :zip])
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,10 @@
+class Address < ApplicationRecord
+  belongs_to :user
+  # has_many :orders
+  validates_presence_of :street,
+                        :city,
+                        :state,
+                        :zip
+
+  # enum nickname: [:home, :work]
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,7 +4,6 @@ class Address < ApplicationRecord
   validates_presence_of :street,
                         :city,
                         :state,
-                        :zip
-
-  # enum nickname: [:home, :work]
+                        :zip,
+                        :nickname
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,6 +1,7 @@
 class Address < ApplicationRecord
   belongs_to :user
-  # has_many :orders
+  has_many :orders
+  
   validates_presence_of :street,
                         :city,
                         :state,

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,5 +1,7 @@
 class Order < ApplicationRecord
   belongs_to :user
+  belongs_to :address
+  
   has_many :order_items
   has_many :items, through: :order_items
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,7 @@
 class User < ApplicationRecord
   before_save { self.email = email.downcase }
 
-  validates_presence_of :email,
-                        :name,
-                        # :address,
-                        # :city,
-                        # :state,
-                        # :zip,
+  validates_presence_of :name,
                         :role,
                         :password_digest
   has_many :orders
@@ -16,7 +11,6 @@ class User < ApplicationRecord
   enum role: ['user', 'merchant', 'admin']
 
   validates :email, uniqueness: true, presence: true
-  # validates_presence_of :password_digest
 
   has_secure_password
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,9 @@ class User < ApplicationRecord
                         :password_digest
   has_many :orders
   has_many :items
+  
   has_many :addresses
+  accepts_nested_attributes_for :addresses
 
   enum role: ['user', 'merchant', 'admin']
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,18 +3,20 @@ class User < ApplicationRecord
 
   validates_presence_of :email,
                         :name,
-                        :address,
-                        :city,
-                        :state,
-                        :zip,
-                        :role
+                        # :address,
+                        # :city,
+                        # :state,
+                        # :zip,
+                        :role,
+                        :password_digest
   has_many :orders
   has_many :items
+  has_many :addresses
 
   enum role: ['user', 'merchant', 'admin']
 
   validates :email, uniqueness: true, presence: true
-  validates_presence_of :password_digest
+  # validates_presence_of :password_digest
 
   has_secure_password
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,9 +4,10 @@ class User < ApplicationRecord
   validates_presence_of :name,
                         :role,
                         :password_digest
+                        
   has_many :orders
   has_many :items
-  
+
   has_many :addresses
   accepts_nested_attributes_for :addresses
 

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -23,7 +23,9 @@
   <h2>Grand Total: <%= number_to_currency(cart.grand_total) %></h2>
 
   <% if current_user?  %>
-    <%= button_to "Check Out", cart_path %>
+    <% current_user.addresses.each do |address| %>
+      <%= button_to "Check Out: Ship to #{address.street}, #{address.city}, #{address.state}", cart_path(address_id: address) %>
+      <% end %>
   <% end %>
   <%= button_to "Empty Cart", { controller: :carts, action: :destroy }, method: :delete %>
 <% else %>

--- a/app/views/user/addresses/edit.html.erb
+++ b/app/views/user/addresses/edit.html.erb
@@ -1,0 +1,18 @@
+<%= form_for [@user, @address], url: profile_address_path(@address) do |f| %>
+  <%= f.label :nickname, "Address Type" %>
+  <%= f.text_field :nickname, required: true %><br>
+
+  <%= f.label :street, "Street Address" %>
+  <%= f.text_field :street, required: true %><br>
+
+  <%= f.label :city %>
+  <%= f.text_field :city, required: true %><br>
+
+  <%= f.label :state %>
+  <%= f.text_field :state, required: true %><br>w2
+
+  <%= f.label :zip %>
+  <%= f.text_field :zip, required: true %><br>
+
+  <%= f.submit "Submit Edits" %>
+<% end %>

--- a/app/views/user/addresses/new.html.erb
+++ b/app/views/user/addresses/new.html.erb
@@ -1,0 +1,18 @@
+<%= form_for [@user, @address], url: profile_addresses_path(@user.id) do |f| %>
+  <%= f.label :nickname, "Address Type" %>
+  <%= f.text_field :nickname, required: true %><br>
+
+  <%= f.label :street, "Street Address" %>
+  <%= f.text_field :street, required: true %><br>
+
+  <%= f.label :city %>
+  <%= f.text_field :city, required: true %><br>
+
+  <%= f.label :state %>
+  <%= f.text_field :state, required: true %><br>w2
+
+  <%= f.label :zip %>
+  <%= f.text_field :zip, required: true %><br>
+
+  <%= f.submit "Submit New Address" %>
+<% end %>

--- a/app/views/user/users/edit.html.erb
+++ b/app/views/user/users/edit.html.erb
@@ -1,29 +1,32 @@
 <div id="profile-edit-form">
-  <%= form_tag profile_path, method: :patch do %>
-    <%= label_tag :name %>
-    <%= text_field_tag :name, current_user.name, required: true %>
-    <br>
-    <%= label_tag :email %>
-    <%= email_field_tag :email, current_user.email, required: true %>
-    <br>
-    <%= label_tag :password %>
-    <%= password_field_tag :password, nil %>
-    <br>
-    <%= label_tag :password_confirmation %>
-    <%= password_field_tag :password_confirmation, nil %>
-    <br>
-    <%= label_tag :address %>
-    <%= text_field_tag :address, current_user.address, required: true %>
-    <br>
-    <%= label_tag :city %>
-    <%= text_field_tag :city, current_user.city, required: true %>
-    <br>
-    <%= label_tag :state %>
-    <%= text_field_tag :state, current_user.state, required: true %>
-    <br>
-    <%= label_tag :zip %>
-    <%= text_field_tag :zip, current_user.zip, required: true %>
-    <br>
-    <%= submit_tag 'Submit Changes' %>
+  <%= form_for(@user, url: profile_path) do |f| %>
+
+    <%= f.label :name %>
+    <%= f.text_field :name, required: true %><br>
+
+    <%= f.label :email %>
+    <%= f.email_field :email, required: true %><br>
+
+    <%= f.fields_for :addresses do |fa| %>
+      <%= fa.label :street %>
+      <%= fa.text_field :street, required: true %><br>
+
+      <%= fa.label :city %>
+      <%= fa.text_field :city, required: true %><br>
+
+      <%= fa.label :state %>
+      <%= fa.text_field :state, required: true %><br>
+
+      <%= fa.label :zip %>
+      <%= fa.text_field :zip, required: true %><br>
+    <% end %>
+
+    <%= f.label :password %>
+    <%= f.password_field :password, required: true %><br>
+
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation, required: true %><br>
+
+    <%= f.submit "Submit Changes" %>
   <% end %>
 </div>

--- a/app/views/user/users/edit.html.erb
+++ b/app/views/user/users/edit.html.erb
@@ -8,6 +8,9 @@
     <%= f.email_field :email, required: true %><br>
 
     <%= f.fields_for :addresses do |fa| %>
+      <%= fa.label :nickname %>
+      <%= fa.text_field :nickname, required: true %><br>
+      
       <%= fa.label :street %>
       <%= fa.text_field :street, required: true %><br>
 

--- a/app/views/user/users/show.html.erb
+++ b/app/views/user/users/show.html.erb
@@ -1,8 +1,13 @@
-<h1><%= current_user.name %></h1>
-<p><%= current_user.email %></p>
-<p><%= current_user.address %></p>
-<p><%= current_user.city %>, <%= current_user.state %></p>
-<p><%= current_user.zip %></p>
+<h1>Name: <%= current_user.name %></h1>
+<p>Email: <%= current_user.email %></p>
+
+<h3>Addresses</h3>
+<% @addresses.each do |address| %>
+  <p>Street Address: <%= address.street %></p>
+  <p>City: <%= address.city %></p>
+  <p>State: <%= address.state %></p>
+  <p>Zip: <%= address.zip %></p>
+<% end %>
 
 <%= link_to "Edit My Profile or Password", profile_edit_path %>
 

--- a/app/views/user/users/show.html.erb
+++ b/app/views/user/users/show.html.erb
@@ -10,6 +10,7 @@
     <p>State: <%= address.state %></p>
     <p>Zip Code: <%= address.zip %></p>
     <%= button_to "Delete Address", profile_address_path(address), method: :delete %>
+    <%= button_to "Edit Address", edit_profile_address_path(address), method: :get %>
   </div>
 <% end %>
 

--- a/app/views/user/users/show.html.erb
+++ b/app/views/user/users/show.html.erb
@@ -3,14 +3,17 @@
 
 <h3>Addresses</h3>
 <% @addresses.each do |address| %>
-  <p>Street Address: <%= address.street %></p>
-  <p>City: <%= address.city %></p>
-  <p>State: <%= address.state %></p>
-  <p>Zip: <%= address.zip %></p>
-  <p>Type: <%= address.nickname %></p>
+  <div id="address-<%= address.id %>">
+    <p>Address Type: <%= address.nickname %></p>
+    <p>Street Address: <%= address.street %></p>
+    <p>City: <%= address.city %></p>
+    <p>State: <%= address.state %></p>
+    <p>Zip Code: <%= address.zip %></p>
+  </div>
 <% end %>
 
 <%= link_to "Edit My Profile or Password", profile_edit_path %>
+<%= link_to "Add Address", new_profile_address_path %>
 
 <% if @user_orders.any? %>
   <p><%= link_to "My Orders", user_orders_path %></p>

--- a/app/views/user/users/show.html.erb
+++ b/app/views/user/users/show.html.erb
@@ -1,7 +1,7 @@
 <h1>Name: <%= current_user.name %></h1>
-<p>Email: <%= current_user.email %></p>
+<h3>Email: <%= current_user.email %></h3>
 
-<h3>Addresses</h3>
+<h3>Address:</h3>
 <% @addresses.each do |address| %>
   <div id="address-<%= address.id %>">
     <p>Address Type: <%= address.nickname %></p>
@@ -9,11 +9,12 @@
     <p>City: <%= address.city %></p>
     <p>State: <%= address.state %></p>
     <p>Zip Code: <%= address.zip %></p>
+    <%= button_to "Delete Address", profile_address_path(address), method: :delete %>
   </div>
 <% end %>
 
-<%= link_to "Edit My Profile or Password", profile_edit_path %>
-<%= link_to "Add Address", new_profile_address_path %>
+<p><%= link_to "Edit My Profile or Password", profile_edit_path %></p>
+<p><%= link_to "Add Address", new_profile_address_path %></p>
 
 <% if @user_orders.any? %>
   <p><%= link_to "My Orders", user_orders_path %></p>

--- a/app/views/user/users/show.html.erb
+++ b/app/views/user/users/show.html.erb
@@ -7,6 +7,7 @@
   <p>City: <%= address.city %></p>
   <p>State: <%= address.state %></p>
   <p>Zip: <%= address.zip %></p>
+  <p>Type: <%= address.nickname %></p>
 <% end %>
 
 <%= link_to "Edit My Profile or Password", profile_edit_path %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,6 +7,9 @@
   <%= f.email_field :email, required: true %><br>
 
   <%= f.fields_for :addresses do |fa| %>
+    <%= fa.label :nickname %>
+    <%= fa.text_field :nickname, required: true %><br>
+
     <%= fa.label :street %>
     <%= fa.text_field :street, required: true %><br>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -4,19 +4,21 @@
   <%= f.text_field :name, required: true %><br>
 
   <%= f.label :email %>
-  <%= f.email_field :email, required: true, value: "" %><br>
+  <%= f.email_field :email, required: true %><br>
 
-  <%= f.label :address %>
-  <%= f.text_field :address, required: true%><br>
+  <%= f.fields_for :addresses do |fa| %>
+    <%= fa.label :street %>
+    <%= fa.text_field :street, required: true %><br>
 
-  <%= f.label :city %>
-  <%= f.text_field :city, required: true %><br>
+    <%= fa.label :city %>
+    <%= fa.text_field :city, required: true %><br>
 
-  <%= f.label :state %>
-  <%= f.text_field :state, required: true %><br>
+    <%= fa.label :state %>
+    <%= fa.text_field :state, required: true %><br>
 
-  <%= f.label :zip %>
-  <%= f.text_field :zip, required: true %><br>
+    <%= fa.label :zip %>
+    <%= fa.text_field :zip, required: true %><br>
+  <% end %>
 
   <%= f.label :password %>
   <%= f.password_field :password, required: true %><br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     get '/', to: "users#show"
     patch '/', to: "users#update"
     get '/edit', to: "users#edit"
-    resources :addresses, only: [:new, :create, :destroy]
+    resources :addresses, only: [:new, :create, :destroy, :edit, :update]
   end
 
   scope :profile, module: :user, as: :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     get '/', to: "users#show"
     patch '/', to: "users#update"
     get '/edit', to: "users#edit"
-    resources :addresses, only: [:new, :create]
+    resources :addresses, only: [:new, :create, :destroy]
   end
 
   scope :profile, module: :user, as: :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     get '/', to: "users#show"
     patch '/', to: "users#update"
     get '/edit', to: "users#edit"
+    resources :addresses, only: [:new, :create]
   end
 
   scope :profile, module: :user, as: :user do

--- a/db/migrate/20190602061200_create_addresses.rb
+++ b/db/migrate/20190602061200_create_addresses.rb
@@ -1,0 +1,13 @@
+class CreateAddresses < ActiveRecord::Migration[5.1]
+  def change
+    create_table :addresses do |t|
+      t.string :street
+      t.string :city
+      t.string :state
+      t.string :zip
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190603222641_add_nickname_column_to_addresses.rb
+++ b/db/migrate/20190603222641_add_nickname_column_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddNicknameColumnToAddresses < ActiveRecord::Migration[5.1]
+  def change
+    add_column :addresses, :nickname, :string, default: "home"
+  end
+end

--- a/db/migrate/20190605015709_add_address_to_orders.rb
+++ b/db/migrate/20190605015709_add_address_to_orders.rb
@@ -1,0 +1,5 @@
+class AddAddressToOrders < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :orders, :address, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190602061200) do
+ActiveRecord::Schema.define(version: 20190603222641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20190602061200) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "nickname", default: "home"
     t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190520220022) do
+ActiveRecord::Schema.define(version: 20190602061200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "addresses", force: :cascade do |t|
+    t.string "street"
+    t.string "city"
+    t.string "state"
+    t.string "zip"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_addresses_on_user_id"
+  end
 
   create_table "items", force: :cascade do |t|
     t.bigint "user_id"
@@ -62,6 +73,7 @@ ActiveRecord::Schema.define(version: 20190520220022) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "addresses", "users"
   add_foreign_key "items", "users"
   add_foreign_key "order_items", "items"
   add_foreign_key "order_items", "orders"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190603222641) do
+ActiveRecord::Schema.define(version: 20190605015709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,8 @@ ActiveRecord::Schema.define(version: 20190603222641) do
     t.integer "status", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "address_id"
+    t.index ["address_id"], name: "index_orders_on_address_id"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
@@ -78,5 +80,6 @@ ActiveRecord::Schema.define(version: 20190603222641) do
   add_foreign_key "items", "users"
   add_foreign_key "order_items", "items"
   add_foreign_key "order_items", "orders"
+  add_foreign_key "orders", "addresses"
   add_foreign_key "orders", "users"
 end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :address, class: Address do
+    association :user, factory: :user
+    sequence(:street) { |n| "Street #{n}" }
+    sequence(:city) { |n| "City #{n}" }
+    sequence(:state) { |n| "State #{n}" }
+    sequence(:zip) { |n| "Zip #{n}" }
+    role { 0 }
+    active { true }
+  end
+end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     sequence(:city) { |n| "City #{n}" }
     sequence(:state) { |n| "State #{n}" }
     sequence(:zip) { |n| "Zip #{n}" }
-    role { 0 }
-    active { true }
+    sequence(:nickname) { |n| "Nickname #{n}" }
   end
 end

--- a/spec/features/admin/admins/show_spec.rb
+++ b/spec/features/admin/admins/show_spec.rb
@@ -4,10 +4,18 @@ RSpec.describe "As an admin user" do
   context "When I log into my dashboard" do
     before :each do
       @admin = create(:admin)
-      @user_1 = create(:user, city: "Glendale", state: "CO")
-      @user_2 = create(:user, city: "Glendale", state: "IA")
-      @user_3 = create(:user, city: "Glendale", state: "CA")
-      @user_4 = create(:user, city: "Golden", state: "CO")
+
+      @user_1 = create(:user)
+      @address_1 = create(:address, user: @user_1, city: "Glendale", state: "CO")
+
+      @user_2 = create(:user)
+      @address_2 = create(:address, user: @user_2, city: "Glendale", state: "IA")
+
+      @user_3 = create(:user)
+      @address_3 = create(:address, user: @user_3, city: "Glendale", state: "CA")
+
+      @user_4 = create(:user)
+      @address_4 = create(:address, user: @user_4, city: "Golden", state: "CO")
 
       @merchant_1 = create(:merchant)
       @item_1 = create(:item, user: @merchant_1, inventory: 20)
@@ -22,20 +30,20 @@ RSpec.describe "As an admin user" do
       @item_8 = create(:item, user: @merchant_2)
 
       #shipped orders
-      @order_1 = create(:shipped_order, user: @user_1)
-      @order_2 = create(:shipped_order, user: @user_2)
-      @order_3 = create(:shipped_order, user: @user_3)
-      @order_4 = create(:shipped_order, user: @user_4)
-      @order_5 = create(:shipped_order, user: @user_3)
+      @order_1 = create(:shipped_order, user: @user_1, address: @address_1)
+      @order_2 = create(:shipped_order, user: @user_2, address: @address_2)
+      @order_3 = create(:shipped_order, user: @user_3, address: @address_3)
+      @order_4 = create(:shipped_order, user: @user_4, address: @address_4)
+      @order_5 = create(:shipped_order, user: @user_3, address: @address_3)
 
       #pending order
-      @order_6 = create(:order, user: @user_3)
+      @order_6 = create(:order, user: @user_3, address: @address_3)
 
       #cancelled order
-      @order_7 = create(:cancelled_order, user: @user_1)
+      @order_7 = create(:cancelled_order, user: @user_1, address: @address_1)
 
       #packaged order
-      @order_8 = create(:packaged_order, user: @user_2)
+      @order_8 = create(:packaged_order, user: @user_2, address: @address_2)
 
       #shipped orders
       @order_item_1 = create(:fulfilled_order_item, item: @item_1, quantity: 2, order: @order_1, price_per_item: 100)
@@ -94,14 +102,23 @@ RSpec.describe "As an admin user" do
 
     it 'should display all orders and correct info' do
       admin = create(:admin)
+
       user_w_order_1 = create(:user)
+      address_1 = create(:address, user: user_w_order_1, city: "Glendale", state: "CO")
+
       user_w_order_2 = create(:user)
+      address_2 = create(:address, user: user_w_order_2, city: "Glendale", state: "IA")
+
       user_w_order_3 = create(:user)
+      address_3 = create(:address, user: user_w_order_3, city: "Glendale", state: "CA")
+
       user_w_order_4 = create(:user)
-      order_1 = create(:packaged_order, user: user_w_order_1)
-      order_2 = create(:order, user: user_w_order_2)
-      order_3 = create(:shipped_order, user: user_w_order_3)
-      order_4 = create(:cancelled_order, user: user_w_order_4)
+      address_4 = create(:address, user: user_w_order_4, city: "Golden", state: "CO")
+
+      order_1 = create(:packaged_order, user: user_w_order_1, address: address_1)
+      order_2 = create(:order, user: user_w_order_2, address: address_2)
+      order_3 = create(:shipped_order, user: user_w_order_3, address: address_3)
+      order_4 = create(:cancelled_order, user: user_w_order_4, address: address_4)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 

--- a/spec/features/carts/checkout_spec.rb
+++ b/spec/features/carts/checkout_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Cart checkout functionality: " do
       @item_2 = create(:item, user: @merchant_1, name: "Chair")
 
       @user_1 = create(:user)
+      @address = create(:address, user: @user_1)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
 
       visit item_path(@item_1)
@@ -35,6 +36,15 @@ RSpec.describe "Cart checkout functionality: " do
       expect(page).to have_link("Order #{Order.last.id}")
       expect(page).to have_content("pending")
       expect(page).to have_content("Cart: 0")
+    end
+
+    # When a user checks out on the cart show page, they will have the ability to choose one of their addresses where they'd like the order shipped.
+    it "I can select an address to ship my order, when I check out" do
+      visit cart_path
+
+      click_button 'Check Out: Ship to'
+
+      expect(page).to have_button("Check Out")
     end
   end
 

--- a/spec/features/carts/show_spec.rb
+++ b/spec/features/carts/show_spec.rb
@@ -126,7 +126,6 @@ RSpec.describe "cart show page", type: :feature do
     end
   end
 
-
   context "as a user with an empty cart" do
     it "should only display, your cart is empty" do
       user = create(:user)

--- a/spec/features/user/users/edit_spec.rb
+++ b/spec/features/user/users/edit_spec.rb
@@ -10,9 +10,10 @@ RSpec.describe "profile edit page" do
       @city = "New York City"
       @state = "NY"
       @zip = "12345"
+      @nickname = "home"
 
       @user = User.create!(name: @name, email: @email, password: @password)
-      @address = @user.addresses.create!(street: @street, city: @city, state: @state, zip: @zip)
+      @address = @user.addresses.create!(street: @street, city: @city, state: @state, zip: @zip, nickname: @nickname)
 
       visit login_path
 
@@ -34,6 +35,7 @@ RSpec.describe "profile edit page" do
       expect(page).to have_field("user[addresses_attributes][0][city]")
       expect(page).to have_field("user[addresses_attributes][0][state]")
       expect(page).to have_field("user[addresses_attributes][0][zip]")
+      expect(page).to have_field("user[addresses_attributes][0][nickname]")
 
       click_button "Submit Changes"
       expect(current_path).to eq(profile_path)
@@ -44,6 +46,7 @@ RSpec.describe "profile edit page" do
       expect(page).to have_content(@address.city)
       expect(page).to have_content(@address.state)
       expect(page).to have_content(@address.zip)
+      expect(page).to have_content(@address.nickname)
     end
 
     it "I can edit my name" do
@@ -112,6 +115,24 @@ RSpec.describe "profile edit page" do
       expect(page).to have_content("Your profile has been updated")
       @user.reload
       expect(@address.reload.zip).to eq(new_zip)
+      expect(@user.password_digest).to eq(original_pw_digest)
+    end
+
+    it "I can edit the nickname (type) of my address" do
+      visit profile_edit_path
+
+      new_nickname = "work"
+      original_pw_digest = @user.password_digest
+
+      fill_in "user[addresses_attributes][0][nickname]", with: new_nickname
+      click_button "Submit Changes"
+
+      expect(page).to have_content(new_nickname)
+      expect(page).to_not have_content(@nickname)
+
+      expect(page).to have_content("Your profile has been updated")
+      @user.reload
+      expect(@address.reload.nickname).to eq(new_nickname)
       expect(@user.password_digest).to eq(original_pw_digest)
     end
 

--- a/spec/features/user/users/edit_spec.rb
+++ b/spec/features/user/users/edit_spec.rb
@@ -3,21 +3,16 @@ require 'rails_helper'
 RSpec.describe "profile edit page" do
   context "as a user" do
     before(:each) do
+      @name = "Abc Def"
       @email = "abc@def.com"
       @password = "pw123"
-      @name = "Abc Def"
-      @address = "123 Abc St"
+      @street = "123 Abc St"
       @city = "New York City"
       @state = "NY"
       @zip = "12345"
-      @user = User.create!(email:    @email,
-                           password: @password,
-                           name:     @name,
-                           address:  @address,
-                           city:     @city,
-                           state:    @state,
-                           zip:      @zip
-                          )
+
+      @user = User.create!(name: @name, email: @email, password: @password)
+      @address = @user.addresses.create!(street: @street, city: @city, state: @state, zip: @zip)
 
       visit login_path
 
@@ -31,24 +26,24 @@ RSpec.describe "profile edit page" do
     it "shows a form to edit my profile data" do
       visit profile_edit_path
 
-      expect(page).to have_field(:name)
-      expect(page).to have_field(:email)
-      expect(page).to have_field(:password)
-      expect(page).to have_field(:password_confirmation)
-      expect(page).to have_field(:address)
-      expect(page).to have_field(:city)
-      expect(page).to have_field(:state)
-      expect(page).to have_field(:zip)
+      expect(page).to have_field("user[name]")
+      expect(page).to have_field("user[email]")
+      expect(page).to have_field("user[password]")
+      expect(page).to have_field("user[password_confirmation]")
+      expect(page).to have_field("user[addresses_attributes][0][street]")
+      expect(page).to have_field("user[addresses_attributes][0][city]")
+      expect(page).to have_field("user[addresses_attributes][0][state]")
+      expect(page).to have_field("user[addresses_attributes][0][zip]")
 
       click_button "Submit Changes"
-
       expect(current_path).to eq(profile_path)
 
       expect(page).to have_content(@user.name)
       expect(page).to have_content(@user.email)
-      expect(page).to have_content(@user.address)
-      expect(page).to have_content("#{@user.city}, #{@user.state}")
-      expect(page).to have_content(@user.zip)
+      expect(page).to have_content(@address.street)
+      expect(page).to have_content(@address.city)
+      expect(page).to have_content(@address.state)
+      expect(page).to have_content(@address.zip)
     end
 
     it "I can edit my name" do
@@ -56,7 +51,7 @@ RSpec.describe "profile edit page" do
 
       new_name = "Bob"
 
-      fill_in :name, with: new_name
+      fill_in "user[name]", with: new_name
       click_button "Submit Changes"
 
       expect(page).to have_content("Your profile has been updated")
@@ -69,12 +64,11 @@ RSpec.describe "profile edit page" do
 
       new_address = "7264 Blah St"
 
-      fill_in :address, with: new_address
+      fill_in "user[addresses_attributes][0][street]", with: new_address
       click_button "Submit Changes"
-
       expect(page).to have_content("Your profile has been updated")
       expect(page).to have_content(new_address)
-      expect(page).to_not have_content(@address)
+      expect(page).to_not have_content(@street)
     end
 
     it "I can edit my city" do
@@ -82,7 +76,7 @@ RSpec.describe "profile edit page" do
 
       new_city = "New Orleans"
 
-      fill_in :city, with: new_city
+      fill_in "user[addresses_attributes][0][city]", with: new_city
       click_button "Submit Changes"
 
       expect(page).to have_content("Your profile has been updated")
@@ -95,7 +89,7 @@ RSpec.describe "profile edit page" do
 
       new_state = "LA"
 
-      fill_in :state, with: new_state
+      fill_in "user[addresses_attributes][0][state]", with: new_state
       click_button "Submit Changes"
 
       expect(page).to have_content("Your profile has been updated")
@@ -109,7 +103,7 @@ RSpec.describe "profile edit page" do
       new_zip = "83649"
       original_pw_digest = @user.password_digest
 
-      fill_in :zip, with: new_zip
+      fill_in "user[addresses_attributes][0][zip]", with: new_zip
       click_button "Submit Changes"
 
       expect(page).to have_content(new_zip)
@@ -117,7 +111,7 @@ RSpec.describe "profile edit page" do
 
       expect(page).to have_content("Your profile has been updated")
       @user.reload
-      expect(@user.zip).to eq(new_zip)
+      expect(@address.reload.zip).to eq(new_zip)
       expect(@user.password_digest).to eq(original_pw_digest)
     end
 
@@ -126,7 +120,7 @@ RSpec.describe "profile edit page" do
 
       new_email = "Bob@Bobbin.com"
 
-      fill_in :email, with: new_email
+      fill_in "user[email]", with: new_email
       click_button "Submit Changes"
 
       expect(page).to have_content("Your profile has been updated")
@@ -140,7 +134,7 @@ RSpec.describe "profile edit page" do
 
       visit profile_edit_path
 
-      fill_in :email, with: new_email
+      fill_in "user[email]", with: new_email
       click_button "Submit Changes"
 
       expect(current_path).to eq(profile_edit_path)
@@ -156,8 +150,8 @@ RSpec.describe "profile edit page" do
       new_password = "newPassword"
       original_pw_digest = @user.password_digest
 
-      fill_in :password, with: new_password
-      fill_in :password_confirmation, with: new_password
+      fill_in "user[password]", with: new_password
+      fill_in "user[password_confirmation]", with: new_password
       click_button "Submit Changes"
 
       expect(page).to have_content("Your profile has been updated")
@@ -171,8 +165,8 @@ RSpec.describe "profile edit page" do
       new_password = "newPassword"
       original_pw_digest = @user.password_digest
 
-      fill_in :password, with: new_password.downcase
-      fill_in :password_confirmation, with: new_password.upcase
+      fill_in "user[password]", with: new_password.downcase
+      fill_in "user[password_confirmation]", with: new_password.upcase
       click_button "Submit Changes"
 
       expect(page).to_not have_content("Your profile has been updated")

--- a/spec/features/user/users/edit_spec.rb
+++ b/spec/features/user/users/edit_spec.rb
@@ -62,13 +62,14 @@ RSpec.describe "profile edit page" do
       expect(page).to_not have_content(@name)
     end
 
-    it "I can edit my address" do
+    it "I can edit my street address" do
       visit profile_edit_path
 
       new_address = "7264 Blah St"
 
       fill_in "user[addresses_attributes][0][street]", with: new_address
       click_button "Submit Changes"
+
       expect(page).to have_content("Your profile has been updated")
       expect(page).to have_content(new_address)
       expect(page).to_not have_content(@street)

--- a/spec/features/user/users/show_spec.rb
+++ b/spec/features/user/users/show_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "profile page" do
     before(:each) do
       @user = User.create!(email: "abc@def.com", password: "pw123", name: "Abc Def")
 
-      @address_1 = @user.addresses.create!(street: "123 Abc St", city: "NYC", state: "NY", zip: "12345")
-      @address_2 = @user.addresses.create!(street: "456 Dcf St", city: "Albany", state: "NY", zip: "67890")
+      @address_1 = @user.addresses.create!(street: "123 Abc St", city: "NYC", state: "NY", zip: "12345", nickname: "home")
+      @address_2 = @user.addresses.create!(street: "456 Dcf St", city: "Albany", state: "NY", zip: "67890", nickname: "work")
 
       allow_any_instance_of(ApplicationController).to receive(:current_user)
         .and_return(@user)
@@ -22,11 +22,13 @@ RSpec.describe "profile page" do
       expect(page).to have_content("#{@address_1.city}")
       expect(page).to have_content("#{@address_1.state}")
       expect(page).to have_content(@address_1.zip)
+      expect(page).to have_content(@address_1.nickname)
 
       expect(page).to have_content(@address_2.street)
       expect(page).to have_content("#{@address_2.city}")
       expect(page).to have_content("#{@address_2.state}")
       expect(page).to have_content(@address_2.zip)
+      expect(page).to have_content(@address_2.nickname)
     end
 
     it "has a link to edit my profile data" do
@@ -35,6 +37,62 @@ RSpec.describe "profile page" do
       click_link "Edit My Profile or Password"
 
       expect(current_path).to eq(profile_edit_path)
+    end
+
+    it "has a button to add an address" do
+      name = "Abc Def"
+      email = "abc@def.com"
+      password = "pw123"
+      street = "789 Ghi St"
+      city = "Chicago"
+      state = "IL"
+      zip = "34567"
+      nickname = "billing"
+
+      address_3 = @user.addresses.create!(street: street, city: city, state: state, zip: zip, nickname: nickname)
+
+      visit profile_path
+
+      expect(page).to have_link("Add Address")
+      click_link "Add Address"
+
+      expect(current_path).to eq(new_profile_address_path)
+
+      fill_in "address[street]", with: street
+      fill_in "address[state]", with: state
+      fill_in "address[city]", with: city
+      fill_in "address[zip]", with: zip
+      fill_in "address[nickname]", with: nickname
+
+      click_button "Submit New Address"
+      expect(current_path).to eq(profile_path)
+
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.email)
+
+      within "#address-#{@address_1.id}" do
+        expect(page).to have_content(@address_1.street)
+        expect(page).to have_content(@address_1.city)
+        expect(page).to have_content(@address_1.state)
+        expect(page).to have_content(@address_1.zip)
+        expect(page).to have_content(@address_1.nickname)
+      end
+
+      within "#address-#{@address_2.id}" do
+        expect(page).to have_content(@address_2.street)
+        expect(page).to have_content(@address_2.city)
+        expect(page).to have_content(@address_2.state)
+        expect(page).to have_content(@address_2.zip)
+        expect(page).to have_content(@address_2.nickname)
+      end
+
+      within "#address-#{address_3.id}" do
+        expect(page).to have_content(address_3.street)
+        expect(page).to have_content(address_3.city)
+        expect(page).to have_content(address_3.state)
+        expect(page).to have_content(address_3.zip)
+        expect(page).to have_content(address_3.nickname)
+      end
     end
   end
 

--- a/spec/features/user/users/show_spec.rb
+++ b/spec/features/user/users/show_spec.rb
@@ -136,6 +136,58 @@ RSpec.describe "profile page" do
       expect(page).to_not have_content(@zip_2)
       expect(page).to_not have_content(@nickname_2)
     end
+
+    it "has a button to edit an address" do
+
+      new_street = "New Street"
+      new_city = "New City"
+      new_state = "New State"
+      new_zip = "33333"
+      new_nickname = "holiday"
+
+      visit profile_path
+
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.email)
+
+      within "#address-#{@address_1.id}" do
+        expect(page).to have_button("Edit Address")
+
+        expect(page).to have_content(@street_1)
+        expect(page).to have_content(@city_1)
+        expect(page).to have_content(@state_1)
+        expect(page).to have_content(@zip_1)
+        expect(page).to have_content(@nickname_1)
+      end
+
+      within "#address-#{@address_2.id}" do
+        expect(page).to have_button("Edit Address")
+
+        click_button "Edit Address"
+
+        expect(current_path).to eq(edit_profile_address_path(@address_2))
+      end
+
+      fill_in "address[street]", with: new_street
+      fill_in "address[state]", with: new_state
+      fill_in "address[city]", with: new_city
+      fill_in "address[zip]", with: new_zip
+      fill_in "address[nickname]", with: new_nickname
+
+      click_button "Submit Edits"
+      expect(current_path).to eq(profile_path)
+
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.email)
+
+      within "#address-#{@address_2.id}" do
+        expect(page).to have_content(new_street)
+        expect(page).to have_content(new_city)
+        expect(page).to have_content(new_state)
+        expect(page).to have_content(new_zip)
+        expect(page).to have_content(new_nickname)
+      end
+    end
   end
 
   context "as a registered user" do

--- a/spec/features/user/users/show_spec.rb
+++ b/spec/features/user/users/show_spec.rb
@@ -194,8 +194,9 @@ RSpec.describe "profile page" do
     it "displays a link to my orders, if I have orders placed in the system" do
       user = create(:user)
       merchant = create(:merchant)
+      address = create(:address)
 
-      order = create(:order, user: user)
+      order = create(:order, user: user, address: address)
 
       item_1 = create(:item, user: merchant)
       item_2 = create(:item, user: merchant)

--- a/spec/features/user/users/show_spec.rb
+++ b/spec/features/user/users/show_spec.rb
@@ -3,27 +3,30 @@ require 'rails_helper'
 RSpec.describe "profile page" do
   context "as a user" do
     before(:each) do
-      @user = User.create!(email:    "abc@def.com",
-                           password: "pw123",
-                           name:     "Abc Def",
-                           address:  "123 Abc St",
-                           city:     "NYC",
-                           state:    "NY",
-                           zip:      "12345"
-                          )
+      @user = User.create!(email: "abc@def.com", password: "pw123", name: "Abc Def")
+
+      @address_1 = @user.addresses.create!(street: "123 Abc St", city: "NYC", state: "NY", zip: "12345")
+      @address_2 = @user.addresses.create!(street: "456 Dcf St", city: "Albany", state: "NY", zip: "67890")
 
       allow_any_instance_of(ApplicationController).to receive(:current_user)
         .and_return(@user)
     end
 
-    it "shows my profile data" do
+    it "shows my profile data with multiple addresses" do
       visit profile_path
 
       expect(page).to have_content(@user.name)
       expect(page).to have_content(@user.email)
-      expect(page).to have_content(@user.address)
-      expect(page).to have_content("#{@user.city}, #{@user.state}")
-      expect(page).to have_content(@user.zip)
+
+      expect(page).to have_content(@address_1.street)
+      expect(page).to have_content("#{@address_1.city}")
+      expect(page).to have_content("#{@address_1.state}")
+      expect(page).to have_content(@address_1.zip)
+
+      expect(page).to have_content(@address_2.street)
+      expect(page).to have_content("#{@address_2.city}")
+      expect(page).to have_content("#{@address_2.state}")
+      expect(page).to have_content(@address_2.zip)
     end
 
     it "has a link to edit my profile data" do

--- a/spec/features/user/users/show_spec.rb
+++ b/spec/features/user/users/show_spec.rb
@@ -5,8 +5,20 @@ RSpec.describe "profile page" do
     before(:each) do
       @user = User.create!(email: "abc@def.com", password: "pw123", name: "Abc Def")
 
-      @address_1 = @user.addresses.create!(street: "123 Abc St", city: "NYC", state: "NY", zip: "12345", nickname: "home")
-      @address_2 = @user.addresses.create!(street: "456 Dcf St", city: "Albany", state: "NY", zip: "67890", nickname: "work")
+      @street_1 = "123 Abc St"
+      @city_1 = "NYC"
+      @state_1 = "NY"
+      @zip_1 = "12345"
+      @nickname_1 = "home"
+
+      @street_2 = "456 Dcf St"
+      @city_2 = "Portland"
+      @state_2 = "Maine"
+      @zip_2 = "67890"
+      @nickname_2 = "work"
+
+      @address_1 = @user.addresses.create!(street: @street_1, city: @city_1, state: @state_1, zip: @zip_1, nickname: @nickname_1)
+      @address_2 = @user.addresses.create!(street: @street_2, city: @city_2, state: @state_2, zip: @zip_2, nickname: @nickname_2)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user)
         .and_return(@user)
@@ -93,6 +105,36 @@ RSpec.describe "profile page" do
         expect(page).to have_content(address_3.zip)
         expect(page).to have_content(address_3.nickname)
       end
+    end
+
+    it "has a button to delete an address" do
+      visit profile_path
+
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.email)
+
+      within "#address-#{@address_1.id}" do
+        expect(page).to have_button("Delete Address")
+        expect(page).to have_content(@address_1.street)
+        expect(page).to have_content(@address_1.city)
+        expect(page).to have_content(@address_1.state)
+        expect(page).to have_content(@address_1.zip)
+        expect(page).to have_content(@address_1.nickname)
+      end
+
+      within "#address-#{@address_2.id}" do
+        expect(page).to have_button("Delete Address")
+
+        click_button "Delete Address"
+
+        expect(current_path).to eq(profile_path)
+      end
+
+      expect(page).to_not have_content(@street_2)
+      expect(page).to_not have_content(@city_2)
+      expect(page).to_not have_content(@state_2)
+      expect(page).to_not have_content(@zip_2)
+      expect(page).to_not have_content(@nickname_2)
     end
   end
 

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe "User Registration form" do
     expect(current_path).to eq('/register')
 
     fill_in "user[name]", with: "Billy"
-    fill_in "user[address]", with: "123 go to santa lane"
-    fill_in "user[city]", with: "aurora"
-    fill_in "user[state]", with: "colorado"
     fill_in "user[email]", with: "billyurrutia@gmail.com"
-    fill_in "user[zip]", with: "123311"
     fill_in "user[password]", with: "1233"
     fill_in "user[password_confirmation]", with: "1233"
+    fill_in "user[addresses_attributes][0][street]", with: "123 go to santa lane"
+    fill_in "user[addresses_attributes][0][city]", with: "aurora"
+    fill_in "user[addresses_attributes][0][state]", with: "colorado"
+    fill_in "user[addresses_attributes][0][zip]", with: "123311"
 
     click_on "Register User"
 
@@ -35,13 +35,13 @@ RSpec.describe "User Registration form" do
       expect(current_path).to eq('/register')
 
       fill_in "user[name]", with: "Billy"
-      fill_in "user[address]", with: "123 go to santa lane"
-      fill_in "user[city]", with: "aurora"
-      fill_in "user[state]", with: "colorado"
       fill_in "user[email]", with: "billyurrutia@gmail.com"
-      fill_in "user[zip]", with: "123311"
       fill_in "user[password]", with: "1233"
       fill_in "user[password_confirmation]", with: "123"
+      fill_in "user[addresses_attributes][0][street]", with: "123 go to santa lane"
+      fill_in "user[addresses_attributes][0][city]", with: "aurora"
+      fill_in "user[addresses_attributes][0][state]", with: "colorado"
+      fill_in "user[addresses_attributes][0][zip]", with: "123311"
 
       click_on "Register User"
 
@@ -51,24 +51,18 @@ RSpec.describe "User Registration form" do
 
   context 'email in use already' do
     it 'gives flash error email in use' do
-      User.create!(email: "ABC@gmail.com",
-                  name: "billy",
-                  city: "miami",
-                  state: "colorado",
-                  password: "123",
-                  zip: "111",
-                  address: "1233 s way")
+      create(:user, email: "ABC@gmail.com")
 
       visit '/register'
 
       fill_in "user[name]", with: "Billy"
-      fill_in "user[address]", with: "123 go to santa lane"
-      fill_in "user[city]", with: "aurora"
-      fill_in "user[state]", with: "colorado"
       fill_in "user[email]", with: "abc@gmail.com"
-      fill_in "user[zip]", with: "123311"
       fill_in "user[password]", with: "1233"
       fill_in "user[password_confirmation]", with: "1233"
+      fill_in "user[addresses_attributes][0][street]", with: "123 go to santa lane"
+      fill_in "user[addresses_attributes][0][city]", with: "aurora"
+      fill_in "user[addresses_attributes][0][state]", with: "colorado"
+      fill_in "user[addresses_attributes][0][zip]", with: "123311"
 
       click_on "Register User"
 

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "User Registration form" do
     fill_in "user[addresses_attributes][0][city]", with: "aurora"
     fill_in "user[addresses_attributes][0][state]", with: "colorado"
     fill_in "user[addresses_attributes][0][zip]", with: "123311"
+    fill_in "user[addresses_attributes][0][nickname]", with: "home"
 
     click_on "Register User"
 
@@ -42,6 +43,7 @@ RSpec.describe "User Registration form" do
       fill_in "user[addresses_attributes][0][city]", with: "aurora"
       fill_in "user[addresses_attributes][0][state]", with: "colorado"
       fill_in "user[addresses_attributes][0][zip]", with: "123311"
+      fill_in "user[addresses_attributes][0][nickname]", with: "home"
 
       click_on "Register User"
 
@@ -63,6 +65,7 @@ RSpec.describe "User Registration form" do
       fill_in "user[addresses_attributes][0][city]", with: "aurora"
       fill_in "user[addresses_attributes][0][state]", with: "colorado"
       fill_in "user[addresses_attributes][0][zip]", with: "123311"
+      fill_in "user[addresses_attributes][0][nickname]", with: "home"
 
       click_on "Register User"
 

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  describe 'validations' do
+    it {should validate_presence_of :street}
+    it {should validate_presence_of :city}
+    it {should validate_presence_of :state}
+    it {should validate_presence_of :zip}
+    # it {should validate_presence_of :nickname}
+  end
+
+  describe 'relationships' do
+    it {should belong_to :user}
+    # it {should have_many :orders}
+  end
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Address, type: :model do
     it {should validate_presence_of :city}
     it {should validate_presence_of :state}
     it {should validate_presence_of :zip}
-    # it {should validate_presence_of :nickname}
+    it {should validate_presence_of :nickname}
   end
 
   describe 'relationships' do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe Address, type: :model do
 
   describe 'relationships' do
     it {should belong_to :user}
-    # it {should have_many :orders}
+    it {should have_many :orders}
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Order, type: :model do
     it {should have_many :order_items}
     it {should have_many(:items).through(:order_items)}
     it {should belong_to :user}
+    it {should belong_to :address}
   end
 
   describe "class methods" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,14 +3,8 @@ include ActionView::Helpers::NumberHelper
 
 RSpec.describe User, type: :model do
   describe 'validations' do
-    it {should validate_presence_of :email}
+    it {should validate_presence_of :name}
     it {should validate_presence_of :role}
-    # it {should validate_presence_of :name}
-    # it {should validate_presence_of :address}
-    # it {should validate_presence_of :city}
-    # it {should validate_presence_of :state}
-    # it {should validate_presence_of :zip}
-
     it {should validate_presence_of :email}
     it {should validate_presence_of :password_digest}
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,53 +58,57 @@ RSpec.describe User, type: :model do
         @item_3 = create(:item, user: @merchant_5)
 
         ####### @user_1
-        @user_1 = create(:user, city: "Springfield", state: "KS")
+        @user_1 = create(:user)
+        @address_1 = create(:address, user: @user_1, city: "Springfield", state: "KS")
 
-        @order_1 = create(:shipped_order, user: @user_1) # total_quantity = 101
+        @order_1 = create(:shipped_order, user: @user_1, address: @address_1) # total_quantity = 101
         # merchant_1:
         @oi_1 = create(:fulfilled_order_item, order: @order_1, item: @item_1, quantity: 100, price_per_item: 0.50)
         # merchant_2:
         @oi_2 = create(:fulfilled_order_item, order: @order_1, item: @item_2, quantity: 1, price_per_item: 30.0)
 
         ####### @user_2
-        @user_2 = create(:user, city: "Springfield", state: "IL")
+        @user_2 = create(:user)
+        @address_2 = create(:address, user: @user_2, city: "Springfield", state: "IL")
 
-        @order_2 = create(:shipped_order, user: @user_2) # total_quantity = 2200
+        @order_2 = create(:shipped_order, user: @user_2, address: @address_2) # total_quantity = 2200
         # merchant_1:
         @oi_7 = create(:fulfilled_order_item, order: @order_2, item: @item_1, quantity: 200, price_per_item: 0.05)
         # merchant_1:
         @oi_3 = create(:fulfilled_order_item, order: @order_2, item: @item_3, quantity: 2000, price_per_item: 100.0)
 
         ####### @user_3
-        @user_3 = create(:user, city: "Topeka", state: "KS")
+        @user_3 = create(:user)
+        @address_3 = create(:address, user: @user_3, city: "Topeka", state: "KS")
 
-        @order_3 = create(:order, user: @user_3) # pending order
+        @order_3 = create(:order, user: @user_3, address: @address_3) # pending order
         # merchant_3 / pending order -- should not be included in stats for sales:
         @oi_4 = create(:fulfilled_order_item, order: @order_3, item: @item_4, quantity: 300, price_per_item: 20.0)
 
-        @order_4 = create(:cancelled_order, user: @user_3)
+        @order_4 = create(:cancelled_order, user: @user_3, address: @address_3)
         # merchant_3 / cancelled order -- should not be included in stats for sales:
         @oi_5 = create(:fulfilled_order_item, order: @order_4, item: @item_4, quantity: 400, price_per_item: 13.0)
 
-        @order_5 = create(:packaged_order, user: @user_3)
+        @order_5 = create(:packaged_order, user: @user_3, address: @address_3)
         # merchant_3 / packaged order -- should not be included in stats for sales:
         @oi_6 = create(:fulfilled_order_item, order: @order_5, item: @item_5, quantity: 410, price_per_item: 25.0)
 
-        @order_7 = create(:shipped_order, user: @user_3) # total_quantity = 1
+        @order_7 = create(:shipped_order, user: @user_3, address: @address_3) # total_quantity = 1
         # merchant_2:
         @oi_9 = create(:fulfilled_order_item, order: @order_7, item: @item_2, quantity: 1, price_per_item: 1.0)
 
-        @order_9 = create(:shipped_order, user: @user_3)
-        @order_10 = create(:shipped_order, user: @user_3)
+        @order_9 = create(:shipped_order, user: @user_3, address: @address_3)
+        @order_10 = create(:shipped_order, user: @user_3, address: @address_3)
 
         ####### @user_4
-        @user_4 = create(:user, city: "Denver", state: "CO")
+        @user_4 = create(:user)
+        @address_4 = create(:address, user: @user_4, city: "Denver", state: "CO")
 
-        @order_8 = create(:shipped_order, user: @user_4) # total_quantity = 1
+        @order_8 = create(:shipped_order, user: @user_4, address: @address_4) # total_quantity = 1
         # merchant_3:
         @oi_10 = create(:fulfilled_order_item, order: @order_8, item: @item_4, quantity: 1, price_per_item: 1.0)
 
-        @order_6 = create(:shipped_order, user: @user_4) # total_quantity = 5
+        @order_6 = create(:shipped_order, user: @user_4, address: @address_4) # total_quantity = 5
         # merchant_4:
         @oi_8 = create(:fulfilled_order_item, order: @order_6, item: @item_6, quantity: 5, price_per_item: 10000.0)
       end
@@ -261,10 +265,17 @@ RSpec.describe User, type: :model do
 
   describe 'instance methods' do
     before :each do
-      @user_1 = create(:user, city: "Glendale", state: "CO")
-      @user_2 = create(:user, city: "Glendale", state: "IA")
-      @user_3 = create(:user, city: "Glendale", state: "CA")
-      @user_4 = create(:user, city: "Golden", state: "CO")
+      @user_1 = create(:user)
+      @address_1 = create(:address, user: @user_1, city: "Glendale", state: "CO")
+
+      @user_2 = create(:user)
+      @address_2 = create(:address, user: @address_2, city: "Glendale", state: "IA")
+
+      @user_3 = create(:user)
+      @address_3 = create(:address, user: @address_3, city: "Glendale", state: "CA")
+
+      @user_4 = create(:user)
+      @address_4 = create(:address, user: @address_4, city: "Golden", state: "CO")
 
       @merchant_1 = create(:merchant)
       @item_1 = create(:item, user: @merchant_1, inventory: 20)
@@ -279,20 +290,20 @@ RSpec.describe User, type: :model do
       @item_8 = create(:item, user: @merchant_2)
 
       #shipped orders
-      @order_1 = create(:shipped_order, user: @user_1)
-      @order_2 = create(:shipped_order, user: @user_2)
-      @order_3 = create(:shipped_order, user: @user_3)
-      @order_4 = create(:shipped_order, user: @user_4)
-      @order_5 = create(:shipped_order, user: @user_3)
+      @order_1 = create(:shipped_order, user: @user_1, address: @address_1)
+      @order_2 = create(:shipped_order, user: @user_2, address: @address_2)
+      @order_3 = create(:shipped_order, user: @user_3, address: @address_3)
+      @order_4 = create(:shipped_order, user: @user_4, address: @address_4)
+      @order_5 = create(:shipped_order, user: @user_3, address: @address_5)
 
       #pending order
-      @order_6 = create(:order, user: @user_3)
+      @order_6 = create(:order, user: @user_3, address: @user_3)
 
       #cancelled order
-      @order_7 = create(:cancelled_order, user: @user_1)
+      @order_7 = create(:cancelled_order, user: @user_1, address: @address_1)
 
       #packaged order
-      @order_8 = create(:packaged_order, user: @user_2)
+      @order_8 = create(:packaged_order, user: @user_2, address: @address_2)
 
       #shipped orders
       @order_item_1 = create(:fulfilled_order_item, item: @item_1, quantity: 2, order: @order_1, price_per_item: 100)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe User, type: :model do
   describe 'validations' do
     it {should validate_presence_of :email}
     it {should validate_presence_of :role}
-    it {should validate_presence_of :name}
-    it {should validate_presence_of :address}
-    it {should validate_presence_of :city}
-    it {should validate_presence_of :state}
-    it {should validate_presence_of :zip}
+    # it {should validate_presence_of :name}
+    # it {should validate_presence_of :address}
+    # it {should validate_presence_of :city}
+    # it {should validate_presence_of :state}
+    # it {should validate_presence_of :zip}
 
     it {should validate_presence_of :email}
     it {should validate_presence_of :password_digest}
@@ -18,6 +18,7 @@ RSpec.describe User, type: :model do
   describe 'relationships' do
     it {should have_many :items}
     it {should have_many :orders}
+    it {should have_many :addresses}
   end
 
   describe 'Class Methods' do


### PR DESCRIPTION
- Complete: When user registers they still provide an address, which becomes their first address entry in the database and nicknamed "home".
- Complete: Users need full CRUD ability for addresses from their Profile page.
- Complete: When a user checks out on the cart show page, they have the ability to choose one of their addresses where they'd like the order shipped.